### PR TITLE
Vitals list can be specified as Plug options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,16 @@ defmodule ExampleVital do
 end
 ```
 
-Add this at config.
+Add this at config. In Plug app :
 
 ```elixir
-# config.exs
-config :komachi_heartbeat, vitals: [ExampleVital]
+forward("/ops", to: KomachiHeartbeat, init_opts: [vitals: []])
+```
+
+In Phoenix app :
+
+```elixir
+forward("/ops", KomachiHeartbeat, vitals: [])
 ```
 
 Now `GET /MOUNT_PATH/heartbeat` calls `ExampleVital.vital/0` & response `ok`.

--- a/lib/komachi_heartbeat/root_vital.ex
+++ b/lib/komachi_heartbeat/root_vital.ex
@@ -11,10 +11,9 @@ defmodule KomachiHeartbeat.RootVital do
   Call & aggregate vital plugins `stats/0`.
   """
   @impl true
-  @spec stats :: {:ok | :error, %{module => Vital.stats()}}
   def stats, do: stats(Application.get_env(:komachi_heartbeat, :vitals, []))
 
-  @doc false
+  @spec stats([module]) :: {:ok | :error, %{module => Vital.stats()}}
   def stats(vitals) do
     Enum.reduce(vitals, {:ok, %{}}, fn vital, {status, results} ->
       stats = if function_exported?(vital, :stats, 0), do: vital.stats(), else: vital.vital()
@@ -34,7 +33,7 @@ defmodule KomachiHeartbeat.RootVital do
   @impl true
   def vital, do: vital(Application.get_env(:komachi_heartbeat, :vitals, []))
 
-  @doc false
+  @spec vital([module]) :: :ok | :error
   def vital(vitals) do
     error_vitals = for vital <- vitals, :ok !== vital.vital(), do: vital
     if [] === error_vitals, do: :ok, else: :error

--- a/test/komachi_heartbeat_test.exs
+++ b/test/komachi_heartbeat_test.exs
@@ -15,10 +15,10 @@ defmodule KomachiHeartbeatTest do
     end
 
     test_with_mock "GET /heartbeat when :error", RootVital, [:passthrough],
-      vital: fn -> :error end do
+      vital: fn _ -> :error end do
       conn = conn(:get, "/heartbeat")
       assert {503, _, "heartbeat:NG"} = sent_resp(KomachiHeartbeat.call(conn, []))
-      assert called(RootVital.vital())
+      assert called(RootVital.vital([]))
     end
   end
 
@@ -29,10 +29,10 @@ defmodule KomachiHeartbeatTest do
     end
 
     test_with_mock "GET /stats when :error", RootVital, [:passthrough],
-      stats: fn -> {:error, %{}} end do
+      stats: fn _ -> {:error, %{}} end do
       conn = conn(:get, "/stats")
       assert {503, _, "{}"} = sent_resp(KomachiHeartbeat.call(conn, []))
-      assert called(RootVital.stats())
+      assert called(RootVital.stats([]))
     end
   end
 


### PR DESCRIPTION
Close #12 

- - -

Migration guide
==
Before : (config.exs)

```elixir
config :komachi_heartbeat, vitals: [ExampleVital]
```

After : 

Plug app.

```elixir
forward "/ops", to: KomachiHeartbeat, init_opts: [vitals: [ExampleVital]]
```

Phoenix app.

```elixir
forward "/ops", KomachiHeartbeat, vitals: [ExampleVital]
```